### PR TITLE
Basic priority queue support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.6-alpine
+MAINTAINER Horst Gutmann <horst@zerokspot.com>
+
+RUN mkdir -p /app/requirements
+ADD requirements/* /app/requirements/
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED 1
+RUN pip install -r requirements/promclient050.txt -r requirements/celery4.txt
+ADD celery_prometheus_exporter.py docker-entrypoint.sh /app/
+ENTRYPOINT ["/bin/sh", "/app/docker-entrypoint.sh"]
+CMD []
+
+EXPOSE 8888

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3.6-alpine
-MAINTAINER Horst Gutmann <horst@zerokspot.com>
 
 RUN mkdir -p /app/requirements
 ADD requirements/* /app/requirements/

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -365,9 +365,10 @@ def main():  # pragma: no cover
         queue_list = opts.queue_list
         if type(opts.queue_list) == str:
             queue_list = [opts.queue_list]
-        if len(opts.queue_list) == 1:
-            queue_list = bytearray(opts.queue_list.pop().encode('utf-8')).decode('unicode_escape').split(',')
+        if len(queue_list) == 1:
+            queue_list = bytearray(queue_list.pop().encode('utf-8')).decode('unicode_escape').split(',')
 
+        logging.info('Monitoring queues {}'.format(", ".join(queue_list)))
         q = QueueLengthMonitoringThread(app=app, queue_list=queue_list)
         q.daemon = True
         q.start()

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -363,10 +363,10 @@ def main():  # pragma: no cover
 
         # CLI argument will likely be a string nested in a list
         queue_list = opts.queue_list
-        if type(opts.queue_list) == list and len(opts.queue_list) == 1:
-            queue_list = bytearray(opts.queue_list.pop().encode('utf-8')).decode('unicode_escape').split(',')
-        elif type(opts.queue_list) == str:
+        if type(opts.queue_list) == str:
             queue_list = [opts.queue_list]
+        if len(opts.queue_list) == 1:
+            queue_list = bytearray(opts.queue_list.pop().encode('utf-8')).decode('unicode_escape').split(',')
 
         q = QueueLengthMonitoringThread(app=app, queue_list=queue_list)
         q.daemon = True

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -362,10 +362,11 @@ def main():  # pragma: no cover
     if opts.queue_list:
 
         # CLI argument will likely be a string nested in a list
+        queue_list = opts.queue_list
         if type(opts.queue_list) == list and len(opts.queue_list) == 1:
             queue_list = bytearray(opts.queue_list.pop().encode('utf-8')).decode('unicode_escape').split(',')
-        else:
-            queue_list = opts.queue_list
+        elif type(opts.queue_list) == str:
+            queue_list = [opts.queue_list]
 
         q = QueueLengthMonitoringThread(app=app, queue_list=queue_list)
         q.daemon = True

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -360,13 +360,14 @@ def main():  # pragma: no cover
     w.start()
 
     if opts.queue_list:
-        if type(opts.queue_list) == str:
-            queue_list = opts.queue_list.split(',')
+
+        # CLI argument will likely be a string nested in a list
+        if type(opts.queue_list) == list and len(opts.queue_list) == 1:
+            queue_list = bytearray(opts.queue_list.pop().encode('utf-8')).decode('unicode_escape').split(',')
         else:
             queue_list = opts.queue_list
 
         q = QueueLengthMonitoringThread(app=app, queue_list=queue_list)
-
         q.daemon = True
         q.start()
 

--- a/celery_prometheus_exporter.py
+++ b/celery_prometheus_exporter.py
@@ -236,7 +236,9 @@ class QueueLengthMonitoringThread(threading.Thread):
             self.set_queue_length(queue, length)
 
     def set_queue_length(self, queue, length):
-        QUEUE_LENGTH.labels(queue).set(length)
+        # This is lazy and needs re-implementing properly, just ensuring the queue names look normal in the exporter
+        sanitized_queue_name = queue.replace('{', '').replace('}', '').replace('\x06', '').replace('\x16', '')
+        QUEUE_LENGTH.labels(sanitized_queue_name).set(length)
 
     def run(self):  # pragma: no cover
         while True:


### PR DESCRIPTION
Adding basic support for priority queues using the Redis priority separator (see https://github.com/celery/kombu/issues/422)

This needs further code porting from https://github.com/mher/flower/blob/master/flower/utils/broker.py#L103 but for now this will allow us to pass in the priority queue list names so that the correct Redis keys will be read.

For now it assumes you know what the queues are named based on knowing what your priority steps are, e.g. 

`QUEUE_LIST="celery,{celery}\x06\x163,{celery}\x06\x166,{celery}\x06\x169"`

This would represent

- celery (priority levels 0-2)
- celery3 (priority levels 3-5)
- celery6 (priority levels 6-8)
- celery9 (priority level 9)